### PR TITLE
PE-7415 Adds option  to connect to database through a SSH tunnel

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,8 +19,11 @@
               files="(DataConverter|FieldsMetadata|JdbcSourceTask|GenericDatabaseDialect).java"/>
 
     <suppress checks="MethodLength"
-              files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask).java"/>
+              files="(DataConverter|GenericDatabaseDialect|JdbcSourceTask|JdbcSourceConnectorConfig).java"/>
 
     <suppress checks="ParameterNumber"
               files="(ColumnDefinition|GenericDatabaseDialect|SqlServerDatabaseDialect|PostgreSqlDatabaseDialect).java"/>
+              
+    <suppress checks="AbbreviationAsWordInName"
+    		  files="(GenericDatabaseDialect|JdbcSourceConnectorConfig).java" />          
 </suppressions>

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -1,0 +1,267 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Deployment pipeline for Kafka JDBC connector code deployment
+Parameters:
+  Application:
+    Type: String
+    Default: kafka-connect-jdbc
+  GithubRepoOwner:
+    Type: String
+    Default: PeakBI
+  GithubRepoName:
+    Type: String
+    Default: kafka-connect-jdbc
+  GithubRepoBranch:
+    Type: String
+    Default: master
+  Stage:
+    Type: String
+    Default: latest
+    AllowedValues: [latest, test, beta, prod]
+  NotificationMonitorFunction:
+    Type: String
+    Default: helper-functions-prod-codepipeline-notify-slack
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Application
+        Parameters:
+          - Application
+          - Stage
+      - Label:
+          default: Source Code Repository
+        Parameters:
+          - GithubRepoOwner
+          - GithubRepoName
+          - GithubRepoBranch
+      - Label:
+          default: CodePipeline Parameters
+        Parameters:
+          - NotificationMonitorFunction
+Resources:
+  ArtifactStoreBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName:
+        Fn::Join:
+          - '-'
+          -
+            - Ref: Application
+            - Ref: Stage
+            - artifactstore
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          -
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      VersioningConfiguration:
+        Status: Suspended
+      AccessControl: BucketOwnerFullControl
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      Tags:
+        - {Key: tenant, Value: platform}
+        - {Key: stage, Value: !Ref Stage}
+        - {Key: service, Value: kafka-connect-jdbc}
+        - {Key: feature, Value: 'ingestion'}
+  Pipeline:
+    Type: AWS::CodePipeline::Pipeline
+    Properties:
+      RoleArn: !GetAtt PipelineRole.Arn
+      Name: !Ref AWS::StackName
+      RestartExecutionOnUpdate: true
+      ArtifactStore:
+        Location:
+          Ref:
+            ArtifactStoreBucket
+        Type: S3
+      Stages:
+        - Name: Source
+          Actions:
+            - InputArtifacts: []
+              Name: Source
+              ActionTypeId:
+                Category: Source
+                Owner: ThirdParty
+                Version: 1
+                Provider: GitHub
+              OutputArtifacts:
+                - Name: SourceOutput
+              Configuration:
+                Owner: !Ref GithubRepoOwner
+                Repo: !Ref GithubRepoName
+                Branch: !Ref GithubRepoBranch
+                OAuthToken: '{{resolve:secretsmanager:GitHubToken:SecretString:GitHubToken}}'
+                PollForSourceChanges: false
+              RunOrder: 1
+        - Name: Deploy
+          Actions:
+          - Name: NotificationMonitor
+            InputArtifacts: []
+            ActionTypeId:
+              Category: Invoke
+              Owner: AWS
+              Version: '1'
+              Provider: Lambda
+            OutputArtifacts: []
+            Configuration:
+              FunctionName:
+                Ref: NotificationMonitorFunction
+              UserParameters:
+                !Sub |
+                  {"pipeline": "${AWS::StackName}"}
+            RunOrder: 1
+          - Name: DeployBackend
+            ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: 1
+                Provider: CodeBuild
+            InputArtifacts:
+              - Name: SourceOutput
+            Configuration:
+                ProjectName: !Ref DeployBackendBuild
+            RunOrder: 1
+  PipelineWebhook:
+    Type: AWS::CodePipeline::Webhook
+    Properties:
+      AuthenticationConfiguration:
+        SecretToken: '{{resolve:secretsmanager:GitHubToken:SecretString:GitHubToken}}'
+      Filters:
+        - JsonPath: $.ref
+          MatchEquals: refs/heads/{Branch}
+      Authentication: GITHUB_HMAC
+      TargetPipeline: !Ref Pipeline
+      TargetAction: Source
+      Name: !Ref AWS::StackName
+      TargetPipelineVersion: 1
+      RegisterWithThirdParty: true
+  PipelineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codepipeline.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AWSCodePipelineFullAccess
+        - arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+      Tags:
+        - {Key: tenant, Value: platform}
+        - {Key: stage, Value: !Ref Stage}
+        - {Key: service, Value: kafka-connect-jdbc}
+        - {Key: feature, Value: 'ingestion'}
+  DeployBackendBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Environment:
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:2.0
+        Type: LINUX_CONTAINER
+        EnvironmentVariables:
+          - {Name: STAGE, Value: !Ref Stage}
+      Name: !Sub ${AWS::StackName}
+      ServiceRole: !Ref DeployBackendBuildRole
+      Source:
+        Type: CODEPIPELINE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                java: openjdk8
+            build:
+              commands:
+                - echo Build started on `date`
+                - cd kafka-connect-jdbc
+                - mvn install -D maven.test.skip=true
+            post_build:
+              commands:
+                - echo Build completed on `date`
+                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://kafka-connect-jdbc/
+      Tags:
+        - {Key: tenant, Value: platform}
+        - {Key: stage, Value: !Ref Stage}
+        - {Key: service, Value: kafka-connect-jdbc}
+        - {Key: feature, Value: ingestion}
+  DeployBackendBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: codebuild.amazonaws.com
+          Action: sts:AssumeRole
+      Policies:
+        -
+          PolicyName: "root"
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Effect: "Allow"
+                Action:
+                  - logs:*
+                  - events:*
+                  - cloudwatch:*
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                  - s3:DeleteObject
+                  - s3:CreateBucket
+                  - s3:DeleteBucket
+                  - s3:ListBucket
+                  - s3:ListBucketVersions
+                  - s3:GetBucketVersioning
+                  - s3:PutBucketVersioning
+                  - s3:GetBucketLocation
+                  - s3:PutLifecycleConfiguration
+                  - s3:PutBucketCORS
+                  - s3:PutBucketNotification
+                  - s3:DeleteBucketNotification
+                  - cloudformation:CreateStack
+                  - cloudformation:CreateUploadBucket
+                  - cloudformation:DeleteStack
+                  - cloudformation:DescribeStackEvents
+                  - cloudformation:DescribeStackResource
+                  - cloudformation:DescribeStackResources
+                  - cloudformation:UpdateStack
+                  - cloudformation:DescribeStacks
+                  - cloudformation:ValidateTemplate
+                  - cloudformation:ListStackResources
+                  - iam:CreateRole
+                  - iam:DeleteRole
+                  - iam:GetRole
+                  - iam:PassRole
+                  - iam:DeleteRolePolicy
+                  - iam:PutRolePolicy
+                  - iam:DetachRolePolicy
+                  - iam:AttachRolePolicy
+                  - ec2:DescribeAccountAttributes
+                  - ec2:DescribeAvailabilityZones
+                  - ec2:DescribeSecurityGroups
+                  - ec2:DescribeSubnets
+                  - ec2:DescribeVpcs
+                  - ec2:CreateNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DetachNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                Resource: "*"
+      Tags:
+        - {Key: tenant, Value: platform}
+        - {Key: stage, Value: !Ref Stage}
+        - {Key: service, Value: kafka-connect-jdbc}
+        - {Key: feature, Value: 'ingestion'}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -184,12 +184,11 @@ Resources:
             build:
               commands:
                 - echo Build started on `date`
-                - cd kafka-connect-jdbc
                 - mvn install -D maven.test.skip=true
             post_build:
               commands:
                 - echo Build completed on `date`
-                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://kafka-connect-jdbc/
+                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://ais-${stage}-kafka-connect-jdbc/
       Tags:
         - {Key: tenant, Value: platform}
         - {Key: stage, Value: !Ref Stage}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -188,7 +188,7 @@ Resources:
             post_build:
               commands:
                 - echo Build completed on `date`
-                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://ais-${stage}-kafka-connect-jdbc/
+                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://ais-$STAGE-kafka-connect-jdbc/
       Tags:
         - {Key: tenant, Value: platform}
         - {Key: stage, Value: !Ref Stage}

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -67,6 +67,34 @@ Resources:
         - {Key: stage, Value: !Ref Stage}
         - {Key: service, Value: kafka-connect-jdbc}
         - {Key: feature, Value: 'ingestion'}
+  CodeStoreBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName:
+        Fn::Join:
+          - '-'
+          -
+            - ais
+            - Ref: Stage
+            - kafka-connect-jdbc
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          -
+            ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      AccessControl: BucketOwnerFullControl
+      VersioningConfiguration:
+        Status: Enabled
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      Tags:
+        - {Key: tenant, Value: platform}
+        - {Key: stage, Value: !Ref Stage}
+        - {Key: service, Value: kafka-connect-jdbc}
+        - {Key: feature, Value: 'ingestion'}
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -188,7 +216,7 @@ Resources:
             post_build:
               commands:
                 - echo Build completed on `date`
-                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.2-SNAPSHOT.jar" kafka-connect-jdbc/target s3://ais-$STAGE-kafka-connect-jdbc/
+                - aws s3 cp --recursive --exclude "*" --include "kafka-connect-jdbc-5.5.1.jar" target/ s3://ais-$STAGE-kafka-connect-jdbc/
       Tags:
         - {Key: tenant, Value: platform}
         - {Key: stage, Value: !Ref Stage}

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>5.1.1</version>
+        <version>5.5.1</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,13 @@
     </repositories>
 
     <dependencies>
+        <!-- For SSH tunnelling -->
+        <dependency>
+            <groupId>com.jcraft</groupId>
+            <artifactId>jsch</artifactId>
+            <version>0.1.55</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+            <version>1.2.17-cp2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>5.2.2-SNAPSHOT</version>
+        <version>5.1.1</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.0.0-SNAPSHOT</version>
+        <version>5.2.2-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -287,7 +287,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final Boolean CONNECT_THROUGH_SSH_DEFAULT = false;
   public static final String CONNECT_THROUGH_SSH_DOC =
       "Boolean to identify if the database has to connected through a SSH tunnel. "
-      + "If configured ``true``, SSH tunnel host, port, username, password/key has to be configured as well."
+      + "If configured ``true``, SSH tunnel host, port, username, password/key has"
+      + " to be configured as well.";
   public static final String CONNECT_THROUGH_SSH_DISPLAY = "Connect through SSH";
 
   public static final String SSH_TUNNEL_HOST_CONFIG = "ssh.tunnel.host";
@@ -311,7 +312,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String SSH_TUNNEL_PASSWORD_DISPLAY = "SSH Password";
 
   public static final String SSH_TUNNEL_KEY_CONFIG = "ssh.tunnel.key";
-  public static final String SSH_TUNNEL_KEY_DEFAULT = "";
+  public static final String SSH_TUNNEL_KEY_DEFAULT = null;
   public static final String SSH_TUNNEL_KEY_DOC = "SSH Tunnel Key";
   public static final String SSH_TUNNEL_KEY_DISPLAY = "SSH Key";
 
@@ -507,7 +508,7 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         SSH_TUNNEL_HOST_DISPLAY
     ).define(
         SSH_TUNNEL_PORT_CONFIG,
-        Type.INTEGER,
+        Type.INT,
         SSH_TUNNEL_PORT_DEFAULT,
         Importance.LOW,
         SSH_TUNNEL_PORT_DOC,

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.source;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import com.jcraft.jsch.JSchException;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -278,9 +279,41 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
 
   public static final String QUERY_SUFFIX_CONFIG = "query.suffix";
   public static final String QUERY_SUFFIX_DEFAULT = "";
-  public static final String QUERY_SUFFIX_DOC = 
+  public static final String QUERY_SUFFIX_DOC =
       "Suffix to append at the end of the generated query.";
   public static final String QUERY_SUFFIX_DISPLAY = "Query suffix";
+
+  public static final String CONNECT_THROUGH_SSH_CONFIG = "connect.through.ssh";
+  public static final Boolean CONNECT_THROUGH_SSH_DEFAULT = false;
+  public static final String CONNECT_THROUGH_SSH_DOC =
+      "Boolean to identify if the database has to connected through a SSH tunnel. "
+      + "If configured ``true``, SSH tunnel host, port, username, password/key has to be configured as well."
+  public static final String CONNECT_THROUGH_SSH_DISPLAY = "Connect through SSH";
+
+  public static final String SSH_TUNNEL_HOST_CONFIG = "ssh.tunnel.host";
+  public static final String SSH_TUNNEL_HOST_DEFAULT = "";
+  public static final String SSH_TUNNEL_HOST_DOC = "SSH Tunnel host";
+  public static final String SSH_TUNNEL_HOST_DISPLAY = "SSH Host";
+
+  public static final String SSH_TUNNEL_PORT_CONFIG = "ssh.tunnel.port";
+  public static final Integer SSH_TUNNEL_PORT_DEFAULT = 0;
+  public static final String SSH_TUNNEL_PORT_DOC = "SSH Tunnel Port";
+  public static final String SSH_TUNNEL_PORT_DISPLAY = "SSH Port";
+
+  public static final String SSH_TUNNEL_USER_CONFIG = "ssh.tunnel.user";
+  public static final String SSH_TUNNEL_USER_DEFAULT = "";
+  public static final String SSH_TUNNEL_USER_DOC = "SSH Tunnel User";
+  public static final String SSH_TUNNEL_USER_DISPLAY = "SSH User";
+
+  public static final String SSH_TUNNEL_PASSWORD_CONFIG = "ssh.tunnel.password";
+  public static final String SSH_TUNNEL_PASSWORD_DEFAULT = "";
+  public static final String SSH_TUNNEL_PASSWORD_DOC = "SSH Tunnel Password";
+  public static final String SSH_TUNNEL_PASSWORD_DISPLAY = "SSH Password";
+
+  public static final String SSH_TUNNEL_KEY_CONFIG = "ssh.tunnel.key";
+  public static final String SSH_TUNNEL_KEY_DEFAULT = "";
+  public static final String SSH_TUNNEL_KEY_DOC = "SSH Tunnel Key";
+  public static final String SSH_TUNNEL_KEY_DISPLAY = "SSH Key";
 
   private static final EnumRecommender QUOTE_METHOD_RECOMMENDER =
       EnumRecommender.in(QuoteMethod.values());
@@ -451,7 +484,68 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.LONG,
         DIALECT_NAME_DISPLAY,
-        DatabaseDialectRecommender.INSTANCE);
+        DatabaseDialectRecommender.INSTANCE
+    ).define(
+        CONNECT_THROUGH_SSH_CONFIG,
+        Type.BOOLEAN,
+        CONNECT_THROUGH_SSH_DEFAULT,
+        Importance.LOW,
+        CONNECT_THROUGH_SSH_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        CONNECT_THROUGH_SSH_DISPLAY
+    ).define(
+        SSH_TUNNEL_HOST_CONFIG,
+        Type.STRING,
+        SSH_TUNNEL_HOST_DEFAULT,
+        Importance.LOW,
+        SSH_TUNNEL_HOST_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.LONG,
+        SSH_TUNNEL_HOST_DISPLAY
+    ).define(
+        SSH_TUNNEL_PORT_CONFIG,
+        Type.INTEGER,
+        SSH_TUNNEL_PORT_DEFAULT,
+        Importance.LOW,
+        SSH_TUNNEL_PORT_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.SHORT,
+        SSH_TUNNEL_PORT_DISPLAY
+    ).define(
+        SSH_TUNNEL_USER_CONFIG,
+        Type.STRING,
+        SSH_TUNNEL_USER_DEFAULT,
+        Importance.LOW,
+        SSH_TUNNEL_USER_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        SSH_TUNNEL_USER_DISPLAY
+    ).define(
+        SSH_TUNNEL_PASSWORD_CONFIG,
+        Type.STRING,
+        SSH_TUNNEL_PASSWORD_DEFAULT,
+        Importance.LOW,
+        SSH_TUNNEL_PASSWORD_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        SSH_TUNNEL_PASSWORD_DISPLAY
+    ).define(
+        SSH_TUNNEL_KEY_CONFIG,
+        Type.STRING,
+        SSH_TUNNEL_KEY_DEFAULT,
+        Importance.LOW,
+        SSH_TUNNEL_KEY_DOC,
+        DATABASE_GROUP,
+        ++orderInGroup,
+        Width.MEDIUM,
+        SSH_TUNNEL_KEY_DISPLAY
+    );
   }
 
   private static final void addModeOptions(ConfigDef config) {
@@ -658,6 +752,8 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
           result.add(id.tableName());
         }
         return result;
+      } catch (JSchException jsche) {
+        throw new ConfigException("Couldn't open SSH tunnel " + jsche);
       } catch (SQLException e) {
         throw new ConfigException("Couldn't open connection to " + dbUrl, e);
       }

--- a/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/TableMonitorThread.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.sql.SQLException;
+import com.jcraft.jsch.JSchException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -140,6 +141,14 @@ public class TableMonitorThread extends Thread {
     try {
       tables = dialect.tableIds(connectionProvider.getConnection());
       log.debug("Got the following tables: {}", tables);
+    } catch (JSchException jsche) {
+      log.error(
+          "Error while establishing SSH tunnel, ignoring and waiting for next table poll"
+          + " interval",
+          jsche
+      );
+      connectionProvider.close();
+      return false;
     } catch (SQLException e) {
       log.error(
           "Error while trying to get updated table list, ignoring and waiting for next table poll"

--- a/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/CachedConnectionProvider.java
@@ -99,8 +99,8 @@ public class CachedConnectionProvider implements ConnectionProvider {
       } catch (JSchException jsche) {
         attempts++;
         if (attempts < maxConnectionAttempts) {
-          log.info("Unable to establish SSH tunnel to database on attempt {}/{}. Will retry in {} ms.", attempts,
-                   maxConnectionAttempts, connectionRetryBackoff, sqle
+          log.info("Unable to establish SSH tunnel on attempt {}/{}. Will retry in {} ms.", 
+                   attempts, maxConnectionAttempts, connectionRetryBackoff, jsche
           );
           try {
             Thread.sleep(connectionRetryBackoff);

--- a/src/main/java/io/confluent/connect/jdbc/util/ConnectionProvider.java
+++ b/src/main/java/io/confluent/connect/jdbc/util/ConnectionProvider.java
@@ -17,6 +17,7 @@ package io.confluent.connect.jdbc.util;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import com.jcraft.jsch.JSchException;
 
 /**
  * A provider of JDBC {@link Connection} instances.
@@ -28,7 +29,7 @@ public interface ConnectionProvider extends AutoCloseable {
    * @return the connection; never null
    * @throws SQLException if there is a problem getting the connection
    */
-  Connection getConnection() throws SQLException;
+  Connection getConnection() throws SQLException, JSchException;
 
   /**
    * Determine if the specified connection is valid.


### PR DESCRIPTION
This provides SSH options in the configuration of JDBC source connector and if SSH is enabled, it establishes a SSH session and connects to the database via port forwarding. 
Parameters to be added to the connector configuration to connect through SSH:

`connect.through.ssh=true`
`ssh.tunnel.host=172.12.12.1`
`ssh.tunnel.port=22`
`ssh.tunnel.user=root`
`ssh.tunnel.password=password` // or ssh.tunnel.key=keyfile.pem