### PR TITLE
PE-7703 Adds table name as a config parameter

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceConnectorConfig.java
@@ -389,6 +389,11 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
   public static final String TENANT_DOC = "Tenant";
   public static final String TENANT_DISPLAY = "Tenant";
 
+  public static final String TABLE_NAME_CONFIG = "table.name";
+  public static final String TABLE_NAME_DEFAULT = "";
+  public static final String TABLE_NAME_DOC = "Table that is being queried";
+  public static final String TABLE_NAME_DISPLAY = "Table name";
+
   public static final String CREDENTIALS_PROVIDER_CONFIG_PREFIX =
       CREDENTIALS_PROVIDER_CLASS_CONFIG.substring(
          0,
@@ -935,7 +940,17 @@ public class JdbcSourceConnectorConfig extends AbstractConfig {
         ++orderInGroup,
         Width.LONG,
         TENANT_DISPLAY
-     );
+     ).define(
+       TABLE_NAME_CONFIG,
+       Type.STRING,
+       TABLE_NAME_DEFAULT,
+       Importance.LOW,
+       TABLE_NAME_DOC,
+       CONNECTOR_GROUP,
+       ++orderInGroup,
+       Width.LONG,
+       TABLE_NAME_DISPLAY
+      );
   }
 
   public static final ConfigDef CONFIG_DEF = baseConfigDef();

--- a/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
+++ b/src/main/java/io/confluent/connect/jdbc/source/JdbcSourceTask.java
@@ -363,13 +363,7 @@ public class JdbcSourceTask extends SourceTask {
 
           if (!topicArn.equals("") && !snsEventPushed.get()) {
             String topicName = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
-            List<String> tableList = config.getList(
-                JdbcSourceTaskConfig.TABLES_CONFIG);
-            if (tableList.size() > 0) {
-              String[] splittedTableName = tableList.get(0).split("\\.");
-              topicName += splittedTableName[splittedTableName.length - 1].replace("`", "")
-                  .replace("\"", "");
-            }
+            topicName += config.getString(JdbcSourceTaskConfig.TABLE_NAME_CONFIG);
             Map<String, String> payload = new HashMap<String, String>();
             payload.put("status", "success");
             payload.put("topic", topicName);
@@ -419,12 +413,7 @@ public class JdbcSourceTask extends SourceTask {
         String topicArn = config.getString(JdbcSourceTaskConfig.SNS_TOPIC_ARN_CONFIG);
         if (!topicArn.equals("")) {
           String topicName = config.getString(JdbcSourceTaskConfig.TOPIC_PREFIX_CONFIG);
-          List<String> tableList = config.getList(JdbcSourceTaskConfig.TABLES_CONFIG);
-          if (tableList.size() > 0) {
-            String[] splittedTableName = tableList.get(0).split("\\.");
-            topicName += splittedTableName[splittedTableName.length - 1].replace("`", "")
-                .replace("\"", "");;
-          }
+          topicName += config.getString(JdbcSourceTaskConfig.TABLE_NAME_CONFIG);
           Map<String, String> payload = new HashMap<String, String>();
           payload.put("status", "failure");
           payload.put("error", sqle.getMessage());


### PR DESCRIPTION
This PR adds a new configuration called `table.name` to accept name of the table that is being queried on. This is being done to avoid split operations to form the topic name that has to be sent in the SNS event payload.